### PR TITLE
Add FuseSoC support and github CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: run-fusesoc-targets
+on: [push]
+
+jobs:
+  build-openlane:
+    runs-on: ubuntu-latest
+    env:
+      REPO : core_usb_cdc
+      VLNV : ultraembedded:core:usb_cdc
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: core_usb_cdc
+      - name: Checkout pdk
+        uses: actions/checkout@v2
+        with:
+          repository: olofk/pdklite
+          path: pdklite
+      - run: echo "PDK_ROOT=$GITHUB_WORKSPACE/pdklite" >> $GITHUB_ENV
+      - run: echo "EDALIZE_LAUNCHER=${GITHUB_WORKSPACE}/$REPO/.github/workflows/openlane_runner.py" >> $GITHUB_ENV
+      - run: pip3 install --user -e "git+https://github.com/olofk/edalize.git#egg=edalize"
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=sky130 $VLNV
+
+  lint-verilator:
+    runs-on: ubuntu-latest
+    env:
+      REPO : core_usb_cdc
+      VLNV : ultraembedded:core:usb_cdc
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: core_usb_cdc
+      - run: sudo apt install verilator
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=lint $VLNV

--- a/.github/workflows/openlane_runner.py
+++ b/.github/workflows/openlane_runner.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+#This script is a launcher script for Edalize
+#Normally Edalize will launch the EDA tools directly, but if the
+#EDALIZE_LAUNCHER environmnet variable is set and points to an executable file,
+#this file will be called with the command-line that Edalize would otherwise
+#have launched.
+#
+#This allows us to define a custom launcher, as in this case where we intercept
+#the call to flow.tcl (the entry point to the openlane flow) and start up a
+#container. If Edalize wants to execute other applications, we just start them
+#the normal way
+
+import os
+import subprocess
+import sys
+
+def enverr(e):
+    print(f"Error: Openlane backend needs environment variable '{e}' to be set")
+    exit(1)
+
+if 'flow.tcl' in sys.argv[1]:
+    pdk_root      = os.environ.get('PDK_ROOT') or enverr('PDK_ROOT')
+    (build_root, work) = os.path.split(os.getcwd())
+
+    image = "efabless/openlane:v0.12"
+
+    prefix = ["docker", "run",
+              "-v", f"{pdk_root}:{pdk_root}",
+              "-v", f"{build_root}:/project",
+              "-e", f"PDK_ROOT={pdk_root}",
+              "-u", f"{os.getuid()}:{os.getgid()}",
+              "-w", f"/project/{work}",
+              image]
+    sys.exit(subprocess.call(prefix+sys.argv[1:]))
+else:
+    sys.exit(subprocess.call(sys.argv[1:]))
+    

--- a/README.md
+++ b/README.md
@@ -33,6 +33,36 @@ This IP has a simple FIFO interface (valid, data, accept) for input and output d
 ##### Testing
 Verified under simulation then tested on FPGA against Linux, Windows and MAC OS-X.
 
+##### FuseSoC support
+
+USB CDC can be linted with verilator or made into a GDSII with OpenLANE
+using FuseSoC. Quick FuseSoC instructions
+
+```
+#install FuseSoC
+pip3 install fusesoc
+
+#Create and enter a new workspace
+mkdir workspace && cd workspace
+
+#Register usb cdc as a library in the workspace
+fusesoc library add usb_cdc /path/to/core_usb_cdc
+#...if repo is available locally or...
+fusesoc library add usb_cdc https://github.com/ultraembedded/core_usb_cdc
+#...to get the upstream repo
+
+#To run linter
+fusesoc run --target=lint ultraembedded:core:usb_cdc
+#List all targets
+fusesoc core show ultraembedded:core:usb_cdc
+
+#Create a GDSII using a dockerized OpenLANE
+#Requires the sky130 PDK and an Edalize launcher script
+export PDK_ROOT=/path/to/sky130_pdk
+export EDALIZE_LAUNCHER=/path/to/openlane_runner.py
+fusesoc run --target=sky130 ultraembedded:core:usb_cdc
+```
+
 ##### References
 * [USB 2.0 Specification](https://usb.org/developers/docs/usb20_docs)
 * [UTMI Specification](https://www.intel.com/content/dam/www/public/us/en/documents/technical-specifications/usb2-transceiver-macrocell-interface-specification.pdf)

--- a/data/sky130.tcl
+++ b/data/sky130.tcl
@@ -1,0 +1,6 @@
+set ::env(CLOCK_PERIOD) "15.6"
+set ::env(CLOCK_PORT) "clk_i"
+set ::env(FP_CORE_UTIL) 45
+set ::env(SYNTH_MAX_FANOUT) 6
+set ::env(PL_TARGET_DENSITY) [ expr ($::env(FP_CORE_UTIL)+5) / 100.0 ]
+

--- a/usb_cdc_core.core
+++ b/usb_cdc_core.core
@@ -1,0 +1,33 @@
+CAPI=2:
+
+name : ultraembedded:core:usb_cdc:0
+description : USB Peripheral Interface (Device) implementation which enumerates as either a high-speed (480Mbit/s) or full-speed (12Mbit/s) CDC-ACM device
+filesets:
+  rtl:
+    files:
+      - src_v/usb_desc_rom.v
+      - src_v/usbf_crc16.v
+      - src_v/usbf_defs.v : {is_include_file : true}
+      - src_v/usbf_device_core.v
+      - src_v/usbf_sie_rx.v
+      - src_v/usbf_sie_tx.v
+      - src_v/usb_cdc_core.v
+    file_type : verilogSource
+
+  openlane: {files: [data/sky130.tcl : {file_type : tclSource}]}
+
+targets:
+  default:
+    filesets : [rtl]
+
+  lint:
+    default_tool : verilator
+    filesets : [rtl]
+    tools:
+      verilator: {mode : lint-only}
+    toplevel: usb_cdc_core
+
+  sky130:
+    default_tool : openlane
+    filesets : [rtl, openlane]
+    toplevel: usb_cdc_core


### PR DESCRIPTION
Through our work on adding FuseSoC support for the OpenLANE flow we noticed there were a lot of [example designs](https://github.com/efabless/openlane/tree/master/designs) in the openlane repo. Rather than adding FuseSoC support there we thought it was much better to do that directly on the upstream cores instead of handing around stale copies of RTL files. Current status of upstreaming can be found [here](https://github.com/klasnordmark/openlane-examples/issues/2) if you're curious

This adds a core description file for the usb cdc core that exposes
targets for linting and for building a GDSII using OpenLANE.

All targets also implemented as Github actions so that they get run on
every push to the repo.